### PR TITLE
 Changed site_url() to home_url()

### DIFF
--- a/wpjm-company-profile-page.php
+++ b/wpjm-company-profile-page.php
@@ -202,7 +202,7 @@ function gma_wpjmcpp_display_job_meta_data() {
   $data = get_post_meta( $post->ID, "_company_name", true);
   $the_new_company_taxonomy = wp_get_post_terms($post->ID, 'companies');
   $single_company_slug = $the_new_company_taxonomy[0]->slug;
-  $url = site_url() . '/company/' . $single_company_slug;
+  $url = home_url() . '/company/' . $single_company_slug;
 
   // Checks if the company name has been added as a tag to the individual job listing
   if (!empty($data)) {


### PR DESCRIPTION
**site_url():**
Retrieves the URL for the current site where WordPress application files (e.g. wp-blog-header.php or the wp-admin/ folder) are accessible.

**home_url():**
Retrieves the URL for the current site where the front end is accessible.

If you have installed WordPress in its own directory the site_url() includes it in the URL. This results in a 404.
I changed this to the home_url. This should work properly regardless of the WordPress directory.